### PR TITLE
Fix copilot keymap and config typo

### DIFF
--- a/config/plugins/ai/copilot.nix
+++ b/config/plugins/ai/copilot.nix
@@ -4,8 +4,8 @@
     copilot-lua = {
       enable = true;
       settings = {
-        panel.enabled = !config.plugins.blink-cmp-copilot.enable;
-        suggestion.enabled = !config.plugins.blink-cmp-copilot.enabled;
+        panel.enabled = !config.plugins.blink-copilot.enable;
+        suggestion.enabled = !config.plugins.blink-copilot.enabled;
       };
     };
     copilot-chat = {
@@ -13,9 +13,13 @@
     };
   };
 
+  # Define a simple keymap to open Copilot Chat.
   keymaps = [
     {
       mode = "n";
+      key = "<leader>ac";
+      action = ":CopilotChat<CR>";
+      options.desc = "Open Copilot Chat";
     }
   ];
 }


### PR DESCRIPTION
## Summary
- fix wrong plugin reference in copilot config
- add a key mapping for launching Copilot Chat

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68682636be4c832caf4b56d09a8a501f