### PR TITLE
Add icons to home manager config

### DIFF
--- a/modules/homeManager.nix
+++ b/modules/homeManager.nix
@@ -2,6 +2,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 let
@@ -16,6 +17,7 @@ in
     programs.nixvim = {
       enable = true;
       imports = [ ../config ];
+      extraSpecialArgs = import ../lib { inherit pkgs; };
     };
   };
 }


### PR DESCRIPTION
## Summary
- include `icons` extra arg in Home Manager module so plugin configs can use icons

## Testing
- `None`

------
https://chatgpt.com/codex/tasks/task_e_686888963798832c9cd884418dd120cf