### PR TITLE
Remove unused extraSpecialArgs in homeManager module

### DIFF
--- a/config/plugins/editor/neotree.nix
+++ b/config/plugins/editor/neotree.nix
@@ -1,4 +1,7 @@
-{ icons, ... }:
+{ ... }:
+let
+  icons = import ../../../lib/icons.nix;
+in
 {
   plugins.neo-tree = {
     enable = true;

--- a/config/plugins/ui/lualine.nix
+++ b/config/plugins/ui/lualine.nix
@@ -1,4 +1,7 @@
-{ icons, ... }:
+{ ... }:
+let
+  icons = import ../../../lib/icons.nix;
+in
 {
   plugins.lualine = {
     enable = true;

--- a/modules/homeManager.nix
+++ b/modules/homeManager.nix
@@ -17,7 +17,6 @@ in
     programs.nixvim = {
       enable = true;
       imports = [ ../config ];
-      extraSpecialArgs = import ../lib { inherit pkgs; };
     };
   };
 }


### PR DESCRIPTION
## Summary
- clean up home manager module to avoid referencing `extraSpecialArgs`
- import icon definitions directly in modules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68688a5ca4f8832cac28f35c773cf6ed